### PR TITLE
Plague Bearer Freeze Fix

### DIFF
--- a/CoPilot.cs
+++ b/CoPilot.cs
@@ -1033,7 +1033,7 @@ namespace CoPilot
                         {
                             if (skill.Id == SkillInfo.plagueBearer.Id)
                             {
-                                if (SkillInfo.ManageCooldown(SkillInfo.plagueBearer, skill) && GetMonsterWithin(Settings.plagueBearerRange) > Settings.plagueBearerMinEnemys && buffs.Exists(x => x.Name == "corrosive_shroud_at_max_damage"))
+                                if (buffs.Exists(x => x.Name == "corrosive_shroud_at_max_damage") && GetMonsterWithin(Settings.plagueBearerRange) > Settings.plagueBearerMinEnemys)
                                 {
                                     Keyboard.KeyPress(GetSkillInputKey(skill.SkillSlotIndex));
                                 }


### PR DESCRIPTION
Fixed freezing issue caused by checking cooldown of Plague Bearer.

Since we only care about the presence of the max damage buff, it's unnecessary to check the cooldown. Rearranged the check to ensure we have the buff before it goes to start counting nearby monsters.