### PR TITLE
fix: autopilot transitions based on party element

### DIFF
--- a/AutoPilot.cs
+++ b/AutoPilot.cs
@@ -480,7 +480,7 @@ namespace CoPilot
 			try
 			{
 				string leaderName = CoPilot.Instance.Settings.autoPilotLeader.Value.ToLower();
-				return CoPilot.Instance.GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Player].FirstOrDefault(x => string.Equals(x.GetComponent<Player>()?.PlayerName.ToLower(), leaderName, StringComparison.OrdinalIgnoreCase));                                                                  string.Equals(x.GetComponent<Player>()?.PlayerName.ToLower(), leaderName, StringComparison.OrdinalIgnoreCase));
+				return CoPilot.Instance.GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Player].FirstOrDefault(x => string.Equals(x.GetComponent<Player>()?.PlayerName.ToLower(), leaderName, StringComparison.OrdinalIgnoreCase));
 			}
 			// Sometimes we can get "Collection was modified; enumeration operation may not execute" exception
 			catch

--- a/PartyElement.cs
+++ b/PartyElement.cs
@@ -53,7 +53,8 @@ namespace CoPilot
                                 //get party element
                                 Element = partyElement,
                                 //party element swirly tp thingo, if in another area it becomes child 4 as child 3 becomes the area string
-                                TpButton = partyElement.Children[partyElement.ChildCount == 4 ? 3 : 2]
+                                TpButton = partyElement.Children[partyElement.ChildCount == 4 ? 3 : 2],
+                                ZoneName = (partyElement.ChildCount == 4) ? partyElement.Children[2].Text : CoPilot.Instance.GameController?.Area.CurrentArea.DisplayName
                             };
 
                             playersInParty.Add(newElement);
@@ -76,6 +77,7 @@ namespace CoPilot
         public string PlayerName { get; set; } = string.Empty;
         public PlayerData Data { get; set; } = new PlayerData();
         public Element Element { get; set; } = new Element();
+        public string ZoneName { get; set; } = string.Empty;
         public Element TpButton { get; set; } = new Element();
 
         public override string ToString()


### PR DESCRIPTION
Changes the logic to use modern systems to dictate if we should transition zones.

Always prefers to swirly over using a label unless absolutely necessary.

Transitions are still done by using a label.