### PR TITLE
Update ImGuiDrawSettings.cs

### DIFF
--- a/ImGuiDrawSettings.cs
+++ b/ImGuiDrawSettings.cs
@@ -949,6 +949,6 @@ internal class ImGuiDrawSettings
             CoPilot.Instance.LogError(e.ToString());
         }
 
-        ImGui.End();
+        //ImGui.End();
     }
 }


### PR DESCRIPTION
remove ImGui.End(), causes hud to crash due to missing ImGui.Begin()